### PR TITLE
Getstart button bug fixed

### DIFF
--- a/src/routes/intro/index.tsx
+++ b/src/routes/intro/index.tsx
@@ -99,7 +99,7 @@ function Intro() {
                             <br />
                             research and translate based.
                         </p>
-                        <Link to="./quran/1">
+                        <Link to="/search">
                             <Button
                                 variant="filled"
                                 size="medium"


### PR DESCRIPTION
The `to` URL of the Getstart link now goes to the `/search`